### PR TITLE
Correction to ObjectID regex

### DIFF
--- a/src/Atmos/EsuObjects.php
+++ b/src/Atmos/EsuObjects.php
@@ -54,7 +54,7 @@ class ObjectId extends Identifier {
 	/**
 	 * Regular expression used to validate identifiers.
 	 */
-	private static $ID_FORMAT = '/^[0-9a-f]{44}$/';
+	private static $ID_FORMAT = '/^[0-9a-f\-]{44,101}$/';
 	
 	/**
 	 * Stores the string representation of the identifier


### PR DESCRIPTION
Regex will work as before and additionally handle new Object Ids which can be 101 characters long and contain hyphens.

Example
ff81f2c405f8663a5ae87672487f798771fa1e71851bfbecf77bf6299dc81f0d-6693c21a-1900-4de2-b366-6850f702ee47